### PR TITLE
fix: try to fix position bug on some devices

### DIFF
--- a/app/src/main/java/com/example/pokerogueoffline/MainActivity.kt
+++ b/app/src/main/java/com/example/pokerogueoffline/MainActivity.kt
@@ -142,10 +142,9 @@ class MainActivity : AppCompatActivity() {
                 var scaleX = webViewWidth / gameWidth;
                 var scaleY = webViewHeight / gameHeight;
                 var scale = Math.min(scaleX, scaleY);
-                gameContainer.style.transform = 'translate(-50%, -50%) scale(' + scale + ')';
+                gameContainer.style.transform = 'scale(' + scale + ')';
                 gameContainer.style.position = 'absolute';
-                gameContainer.style.left = '50%';
-                gameContainer.style.top = '50%';
+                gameContainer.style.transformOrigin = 'left top';
             })();
             """,
                     null
@@ -252,7 +251,8 @@ class MainActivity : AppCompatActivity() {
             var scaleX = webViewWidth / gameWidth;
             var scaleY = webViewHeight / gameHeight;
             var scale = Math.min(scaleX, scaleY);
-            gameContainer.style.transform = 'translate(-50%, -50%) scale(' + scale + ')';
+            gameContainer.style.transform = 'scale(' + scale + ')';
+            gameContainer.style.transformOrigin = 'left top';
         })();
         """,
             null


### PR DESCRIPTION
fix Admiral-Billy/Pokerogue-App#126
Use transformOrigin = ‘left top’ instead of the transform and position attributes.
Tested on 1600×900,2400×1080 (and rotation) using simulator.